### PR TITLE
Session token

### DIFF
--- a/pharo-repository/AWS-Core/AWSConfig.class.st
+++ b/pharo-repository/AWS-Core/AWSConfig.class.st
@@ -24,7 +24,7 @@ AWSConfig >> accessKeyId: anObject [
 
 { #category : #accessing }
 AWSConfig >> sessionToken [
-	^self  at: #accessKeyId ifAbsent: []
+	^self  at: #sessionToken ifAbsent: []
 ]
 
 { #category : #accessing }

--- a/pharo-repository/AWS-Core/AWSConfig.class.st
+++ b/pharo-repository/AWS-Core/AWSConfig.class.st
@@ -23,6 +23,16 @@ AWSConfig >> accessKeyId: anObject [
 ]
 
 { #category : #accessing }
+AWSConfig >> sessionToken [
+	^self  at: #accessKeyId ifAbsent: []
+]
+
+{ #category : #accessing }
+AWSConfig >> sessionToken: anObject [
+	^self  at: #sessionToken put: anObject
+]
+
+{ #category : #accessing }
 AWSConfig >> apiVersion [
 	^self  at: #apiVersion ifAbsent: []
 ]

--- a/pharo-repository/AWS-S3/AWSS3.class.st
+++ b/pharo-repository/AWS-S3/AWSS3.class.st
@@ -34,6 +34,7 @@ AWSS3 >> createRequest: aRequestBody url: url method: method andBucketName: buck
 	
 	request entity:(ZnEntity readBinaryFrom: aRequestBody asByteArray readStream usingType: ZnMimeType textPlain andLength: aRequestBody byteSize). 
 	request headers at:'host' put: hostUrl.
+	self awsConfig sessionToken ifNotNil: [ request headers at:'X-Amz-Security-Token' put: self awsConfig sessionToken ].	
 	request headers at:'x-amz-content-sha256' put: (SHA256 new hashMessage: aRequestBody) hex.
 	request headers at:'x-amz-date' put: datetimeString.
 	request setAuthorization: ( SignatureV4 creatAuthorization: request andConfig: self awsConfig andDateTime: datetimeString andOption: nil ) .

--- a/pharo-repository/BaselineOfAWS/BaselineOfAWS.class.st
+++ b/pharo-repository/BaselineOfAWS/BaselineOfAWS.class.st
@@ -36,7 +36,7 @@ BaselineOfAWS >> baseline: spec [
 			spec
 				package: 'AWS-Core';
 				package: 'AWS-DynamoDB' with: [ spec requires: #('AWS-Core') ];
-				package: 'AWS-S3' with: [ spec requires: #('AWS-Core') ];
+				package: 'AWS-S3' with: [ spec requires: #('AWS-Core' 'XMLParser') ];
 				package: 'AWS-ElasticTranscoder' with: [ spec requires: #('AWS-Core') ];
 				package: 'AWS-STS' with: [ spec requires: #('AWS-Core') ];
 				package: 'AWS-CloudFront' with: [ spec requires: #('AWS-Core') ];


### PR DESCRIPTION
To use IAM auth from Lambda, for instance, we need the sercurity token to be send in the header.
cf:
https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html

It might be true in other usecase and other client, but I only have Lambda->S3 need so far... So I focused on that... 
But it would definitivaly deserve to be a general feature from AWS-core