### PR TITLE
Znurl>>printpathstring doen't encode properly the canoncal URI.

### DIFF
--- a/pharo-repository/AWS-Core/AWSConfig.class.st
+++ b/pharo-repository/AWS-Core/AWSConfig.class.st
@@ -23,16 +23,6 @@ AWSConfig >> accessKeyId: anObject [
 ]
 
 { #category : #accessing }
-AWSConfig >> sessionToken [
-	^self  at: #sessionToken ifAbsent: []
-]
-
-{ #category : #accessing }
-AWSConfig >> sessionToken: anObject [
-	^self  at: #sessionToken put: anObject
-]
-
-{ #category : #accessing }
 AWSConfig >> apiVersion [
 	^self  at: #apiVersion ifAbsent: []
 ]
@@ -121,6 +111,16 @@ AWSConfig >> serviceName [
 { #category : #accessing }
 AWSConfig >> serviceName: anObject [
 	^self  at: #serviceName put: anObject
+]
+
+{ #category : #accessing }
+AWSConfig >> sessionToken [
+	^self  at: #sessionToken ifAbsent: []
+]
+
+{ #category : #accessing }
+AWSConfig >> sessionToken: anObject [
+	^self  at: #sessionToken put: anObject
 ]
 
 { #category : #accessing }

--- a/pharo-repository/AWS-Core/SignatureV4.class.st
+++ b/pharo-repository/AWS-Core/SignatureV4.class.st
@@ -83,7 +83,7 @@ SignatureV4 >> createCanonicalRequest: request andOption: aDictionary [
 	cs := request method , String lf.
 
 	"Add the canonical URI parameter, followed by a newline character. The canonical URI is the URI-encoded version of the absolute path component of the URI—everything in the URI from the HTTP host to the question mark character (?) that begins the query string parameters (if any). Then add a newline character."
-	cs := cs , request url pathPrintString , String lf.
+	cs := cs , request url awsEncodeCanonicalUri, String lf.
 
 	"Add the canonical query string, followed by a newline character. If the request does not include a query string, set this value in the canonical query to an empty string (essentially, a blank line). The example query does not contain a query string."
 	queryDict := request url query.

--- a/pharo-repository/AWS-Core/ZnUrl.extension.st
+++ b/pharo-repository/AWS-Core/ZnUrl.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #ZnUrl }
+
+{ #category : #'*AWS-Core' }
+ZnUrl >> awsEncodeCanonicalUri [
+	^ String
+		streamContents: [ :stream | 
+			self hasPath
+				ifFalse: [ ^ stream nextPut: $/ ].
+			segments
+				do: [ :each | 
+					stream nextPut: $/.
+					each == #/
+						ifFalse: [ self encode: each on: stream ] ] ]
+]


### PR DESCRIPTION
$: is kept as it is defined as a safe character which is wrong according to RFC 3986 (but amazon needs it this way)... It should be turned into %3A. 
We could consider using the String>>urlEncoded method, but this one turns $/ into %2F... which is wrong for AWS....
So I implemented my own one... 
It is specially important when there is an ARN in the uri.

see doc: https://docs.aws.amazon.com/fr_fr/general/latest/gr/sigv4-create-canonical-request.html